### PR TITLE
Take screen shot of failing e2e test and generate PNG

### DIFF
--- a/e2e/screen.shots.js
+++ b/e2e/screen.shots.js
@@ -1,0 +1,27 @@
+// File stream
+var fs = require('fs');
+
+// Abstract writing screen shot to a file 
+function writeScreenShot(data, filename) {
+    var directory = './e2e/failures/';
+    
+      // Create directory to store files
+      if(!fs.existsSync(directory)) {
+        fs.mkdirSync(directory);
+      };
+    
+    var stream = fs.createWriteStream(directory + filename);
+    stream.write(new Buffer(data, 'base64'));
+    stream.end();
+}
+
+// After each failing test, take a screen shot
+afterEach(function() {
+  var passed = jasmine.getEnv().currentSpec.results().passed();
+
+    if(!passed) {
+      browser.takeScreenshot().then(function (png) {
+        writeScreenShot(png, 'e2e-fail.png');
+      });
+    }
+  });


### PR DESCRIPTION
This introduction is to have Protractor take a screen shot of failing e2e tests and generate a PNG file to help debug the failing scenario.

@digitalgravy @craigrich - please review and merge if OK.

Screen shot of where the file is stored in the directory:
![failing-screen-shot](https://cloud.githubusercontent.com/assets/10408095/5668576/971cc96a-9768-11e4-892f-c73044db3764.png)
