### PR TITLE
Add failures folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bower_components/
 .sass-cache/
 .tmp/
 dist/
+/e2e/failures/


### PR DESCRIPTION
Just a quick update to add the failures folder to gitignore as discussed.

@digitalgravy - please review and merge if OK.