### PR TITLE
Ability for failing Spec to be name of its corresponding PNG

### DIFF
--- a/e2e/screen.shots.js
+++ b/e2e/screen.shots.js
@@ -17,12 +17,16 @@ function writeScreenShot(data, filename) {
 
 // After each failing test, take a screen shot
 afterEach(function() {
-  var passed = jasmine.getEnv().currentSpec.results().passed(),
-    currentSpec = jasmine.getEnv().currentSpec.description.split(' ').join('-');
+  var 
+    currentSpec = jasmine.getEnv().currentSpec,
+    passed = currentSpec.results().passed(),
+    suiteName = currentSpec.suite.description.split(' ').join('-');
+    description = currentSpec.description.split(' ').join('-'),
+    now = new Date().toISOString().replace(/T/, '_').replace(/\:(.+)/, '');
 
-    if(!passed) {
+    if(!passed) { 
       browser.takeScreenshot().then(function (png) {
-        writeScreenShot(png, 'e2e-fail_' + currentSpec + '.png');
+        writeScreenShot(png, 'e2e-fail_-_' + suiteName + '_-_' + description + '_-_'+ now +'.png');
       });
     }
   });

--- a/e2e/screen.shots.js
+++ b/e2e/screen.shots.js
@@ -17,11 +17,12 @@ function writeScreenShot(data, filename) {
 
 // After each failing test, take a screen shot
 afterEach(function() {
-  var passed = jasmine.getEnv().currentSpec.results().passed();
+  var passed = jasmine.getEnv().currentSpec.results().passed(),
+    currentSpec = jasmine.getEnv().currentSpec.description.split(' ').join('-');
 
     if(!passed) {
       browser.takeScreenshot().then(function (png) {
-        writeScreenShot(png, 'e2e-fail.png');
+        writeScreenShot(png, 'e2e-fail_' + currentSpec + '.png');
       });
     }
   });


### PR DESCRIPTION
This introduction is to update the way the PNG of the failing e2e tests are generated. In https://github.com/thatAKGuy/EBO/pull/9, the PNGs would always use the same name. So if you had more than one failing Spec, the latest one would always overwrite the previous - not spotted for single tests.

This update will make the name of each failing Spec the name of its corresponding PNG file:

![failed-spec-name](https://cloud.githubusercontent.com/assets/10408095/5700727/2fd7fc6e-9a3a-11e4-96f0-22ecda2c5a17.png)

It also means you know from the name exactly what Specs are misbehaving and would know where to look.

@digitalgravy @craigrich - please review and merge if OK.
